### PR TITLE
Added DynamicVariableSpace with a User variable

### DIFF
--- a/MyInspectors/Properties/AssemblyInfo.cs
+++ b/MyInspectors/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.2")]
-[assembly: AssemblyFileVersion("2.0.2")]
+[assembly: AssemblyVersion("2.0.3")]
+[assembly: AssemblyFileVersion("2.0.3")]


### PR DESCRIPTION
I added this so if a user wants to easily determine who owns the newly spawned inspector because going off allocating user alone can be funky.